### PR TITLE
refactor: collapse button handlers into BUTTONS table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-hooks/hook.log
+hooks/*.log
 *.zip
 *.webloc
 *.key

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Two boards are supported:
 
 | Board | LED output |
 |-------|-----------|
-| Raspberry Pi Pico | 3× discrete LEDs (GP10/GP11/GP12) |
+| Raspberry Pi Pico | 3× discrete LEDs (GP2/GP3/GP4) |
 | Waveshare RP2040 Zero | Built-in RGB NeoPixel (GP16) |
 
 Board type is auto-detected — no manual configuration needed.
 
-Both use the same GPIO pins for buttons (GP2/GP3/GP4). See [`hardware/wiring.md`](hardware/wiring.md) for full pin assignments.
+Both use the same GPIO pins for buttons (GP14/GP15/GP26). See [`hardware/wiring.md`](hardware/wiring.md) for full pin assignments.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gavel
+# Gavel (270)
 
 <img src="docs/icon-128.png" alt="Gavel icon" align="right"/>
 
@@ -19,10 +19,12 @@ A physical controller for [Claude Code](https://claude.ai/code).
 
 Two boards are supported:
 
-| Board | LED output | Config |
-|-------|-----------|--------|
-| Raspberry Pi Pico | 3× discrete LEDs (GP10/GP11/GP12) | `USE_NEOPIXEL = False` |
-| Waveshare RP2040 Zero | Built-in RGB NeoPixel (GP16) | `USE_NEOPIXEL = True` |
+| Board | LED output |
+|-------|-----------|
+| Raspberry Pi Pico | 3× discrete LEDs (GP10/GP11/GP12) |
+| Waveshare RP2040 Zero | Built-in RGB NeoPixel (GP16) |
+
+Board type is auto-detected — no manual configuration needed.
 
 Both use the same GPIO pins for buttons (GP2/GP3/GP4). See [`hardware/wiring.md`](hardware/wiring.md) for full pin assignments.
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -70,7 +70,7 @@ Notification flash patterns:
 | Component       | Part                        | Notes                                  |
 |-----------------|-----------------------------|----------------------------------------|
 | Microcontroller | Waveshare RP2040 Zero       | RP2040, CircuitPython firmware         |
-| Buttons (×3)    | 6×6mm tactile switch        | Internal pull-up, active low, GP2/3/4  |
+| Buttons (×3)    | 6×6mm tactile switch        | Internal pull-up, active low, GP14/15/26 |
 | Reset button    | 6×6mm tactile switch        | RESET pin to GND, no resistor          |
 | LED output      | Built-in RGB NeoPixel       | GP16 (WS2812), color-coded per event   |
 | Connection      | USB-C cable                 | Powers the board + HID + serial        |
@@ -79,7 +79,7 @@ Notification flash patterns:
 
 | Board                  | LED output                    |
 |------------------------|-------------------------------|
-| Raspberry Pi Pico      | 3× discrete LEDs (GP10/11/12) |
+| Raspberry Pi Pico      | 3× discrete LEDs (GP2/3/4) |
 | Seeed XIAO RP2040      | Built-in RGB NeoPixel         |
 
 Board type is detected automatically at runtime via `board.board_id` — no

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -1,0 +1,137 @@
+# Gavel Kit Test Checklist
+
+Work through each section in order. All steps must pass before shipping or using the device.
+
+---
+
+## 1. PCB Inspection (Before Soldering)
+
+Visual checks before applying any heat:
+
+- [ ] No visible shorts between adjacent pads (use a magnifier if needed)
+- [ ] All pads are clean — no oxidation or solder mask damage
+- [ ] Top plate aligns correctly over the main PCB
+
+---
+
+## 2. Firmware Flash
+
+**Goal:** Confirm the RP2040-Zero accepts firmware.
+
+1. Hold the **BOOT** button on the RP2040-Zero
+2. Plug the USB cable into your Mac while holding BOOT
+3. Release BOOT — a drive named `RPI-RP2` should appear in Finder
+4. Drag the CircuitPython `.uf2` file onto `RPI-RP2`
+5. The drive will disappear and reappear as `CIRCUITPY`
+
+- [ ] `RPI-RP2` appears when entering bootloader mode
+- [ ] `CIRCUITPY` drive mounts after flashing
+
+---
+
+## 3. Library and Firmware Files
+
+Copy required files to `CIRCUITPY`:
+
+| File / Folder | Destination |
+|---|---|
+| `adafruit_hid/` | `CIRCUITPY/lib/adafruit_hid/` |
+| `neopixel.mpy` | `CIRCUITPY/lib/neopixel.mpy` |
+| `firmware/boot.py` | `CIRCUITPY/boot.py` |
+| `firmware/code.py` | `CIRCUITPY/code.py` |
+
+After copying, **power cycle** (unplug and replug USB).
+
+- [ ] All files copied without error
+- [ ] Board reboots cleanly after power cycle
+
+---
+
+## 4. LED Self-Test (Idle State)
+
+With the board powered and `code.py` running:
+
+- [ ] The built-in RGB NeoPixel lights up **white** (waiting for input state)
+
+If the LED stays off or shows an unexpected color, confirm your board is a supported NeoPixel board — board type is auto-detected from the board ID.
+
+---
+
+## 5. Button Test — USB HID
+
+**Goal:** Each button sends the correct keypress to the Mac.
+
+1. Open any text editor on your Mac (e.g., TextEdit)
+2. Click inside the document so it has focus
+3. Press each button on Gavel one at a time
+
+| Button | Expected keypress | Expected LED color |
+|---|---|---|
+| Allow Once | `1` | Green |
+| Always Allow | `2` | Blue |
+| Reject | `3` | Red |
+
+- [ ] Allow Once sends `1` and LED turns green
+- [ ] Always Allow sends `2` and LED turns blue
+- [ ] Reject sends `3` and LED turns red
+- [ ] LED returns to white after ~1 second
+
+---
+
+## 6. Serial Port Detection
+
+**Goal:** Confirm the Mac can see both USB serial ports.
+
+Run in Terminal:
+
+```sh
+ls /dev/tty.usbmodem*
+```
+
+Expected output: two ports, for example:
+
+```
+/dev/tty.usbmodem1101
+/dev/tty.usbmodem1103
+```
+
+- [ ] Two `tty.usbmodem*` ports appear
+
+---
+
+## 7. Hook Integration Test
+
+**Goal:** Confirm Claude Code hooks trigger LED responses.
+
+1. Run `./install.sh --deploy` to register hooks
+2. Start a Claude Code session
+3. Ask Claude to run any tool (e.g., `list files`)
+
+| Hook event | Expected LED behavior |
+|---|---|
+| `PreToolUse` (permission prompt) | All LEDs solid on |
+| `PostToolUse` (after tool runs) | All LEDs off → return to white |
+| `Notification` (warn) | Three medium flashes |
+| `Notification` (error) | Five fast red flashes |
+
+- [ ] LED responds to `PreToolUse`
+- [ ] LED responds to `PostToolUse`
+- [ ] Notification events produce correct flash patterns
+
+---
+
+## 8. Reset Button Test
+
+1. Press the **RESET** button on the RP2040-Zero
+2. The board should reboot and the NeoPixel should return to white within 3 seconds
+
+- [ ] Reset button reboots the board cleanly
+- [ ] Firmware restarts without needing to replug USB
+
+---
+
+## Pass Criteria
+
+All checkboxes above must be checked before the kit is considered ready to ship or use.
+
+If any step fails, refer to [`hardware/wiring.md`](hardware/wiring.md) for pin assignments and [`README.md`](README.md) for setup instructions.

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -54,7 +54,7 @@ hardware at runtime. This eliminates any manual configuration. All subsequent
 LED code branches on `USE_NEOPIXEL`:
 
 - `True`  → NeoPixel path (single RGB LED on `board.NEOPIXEL`)
-- `False` → PWM path (three separate LEDs on GP10 / GP11 / GP12)
+- `False` → PWM path (three separate LEDs on GP2 / GP3 / GP4)
 
 ---
 
@@ -193,9 +193,9 @@ Each LED maps to a button:
 
 | LED index | GPIO  | Color | Button        |
 |-----------|-------|-------|---------------|
-| 0         | GP10  | Green | Allow Once    |
-| 1         | GP11  | Green | Always Allow  |
-| 2         | GP12  | Red   | Reject        |
+| 0         | GP2   | Green | Allow Once    |
+| 1         | GP3   | Green | Always Allow  |
+| 2         | GP4   | Red   | Reject        |
 
 ---
 

--- a/firmware/code.py
+++ b/firmware/code.py
@@ -73,11 +73,10 @@ btn_reject       = make_button(board.GP4)
 # ── LED setup ─────────────────────────────────────────────────
 import pwmio
 
-# RP2040 Zero PCB uses common-anode LEDs (active-low): GPIO LOW = on.
-# Pico uses common-cathode (active-high): GPIO HIGH = on.
-BRIGHT = 0     if USE_NEOPIXEL else 65535
-DIM    = 57535 if USE_NEOPIXEL else 8000
-OFF    = 65535 if USE_NEOPIXEL else 0
+# Both boards: anode → GPIO, cathode → GND (active-high): GPIO HIGH = on.
+BRIGHT = 65535
+DIM    = 8000
+OFF    = 0
 
 def make_led(pin):
     return pwmio.PWMOut(pin, frequency=1000, duty_cycle=OFF)

--- a/firmware/code.py
+++ b/firmware/code.py
@@ -71,87 +71,84 @@ btn_always_allow = make_button(board.GP3)
 btn_reject       = make_button(board.GP4)
 
 # ── LED setup ─────────────────────────────────────────────────
+import pwmio
+
+def make_led(pin):
+    return pwmio.PWMOut(pin, frequency=1000, duty_cycle=0)
+
+led_allow_once   = make_led(board.GP10)
+led_always_allow = make_led(board.GP11)
+led_reject       = make_led(board.GP12)
+LEDS   = [led_allow_once, led_always_allow, led_reject]
+BRIGHT = 65535
+DIM    = 8000
+OFF    = 0
+
 if USE_NEOPIXEL:
     import neopixel
     np = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=1.0, auto_write=True)
-
-    def all_leds_off():
-        np[0] = (0, 0, 0)
-
-    def set_waiting_leds():
-        np[0] = (255, 255, 255)  # white = waiting for input
-
-    def neo_flash(r, g, b, times=1, on_ms=200, off_ms=80):
-        for _ in range(times):
-            np[0] = (r, g, b)
-            time.sleep(on_ms / 1000)
-            np[0] = (0, 0, 0)
-            time.sleep(off_ms / 1000)
-
-    def flash_all(times=3, on_ms=80, off_ms=80):
-        neo_flash(255, 255, 255, times, on_ms, off_ms)
-
     breath_next = 0
 
-else:
-    import pwmio
+KNIGHT_SEQUENCE = [0, 1, 2, 1]
+knight_step = 0
+knight_prev = -1
+knight_next = 0
 
-    def make_led(pin):
-        return pwmio.PWMOut(pin, frequency=1000, duty_cycle=0)
+def all_leds_off():
+    if USE_NEOPIXEL:
+        np[0] = (0, 0, 0)
+    for led in LEDS:
+        led.duty_cycle = OFF
 
-    led_allow_once   = make_led(board.GP10)
-    led_always_allow = make_led(board.GP11)
-    led_reject       = make_led(board.GP12)
-    LEDS   = [led_allow_once, led_always_allow, led_reject]
-    BRIGHT = 65535
-    DIM    = 8000
-    OFF    = 0
+def set_led(index, duty):
+    LEDS[index].duty_cycle = duty
 
-    def all_leds_off():
-        for led in LEDS:
-            led.duty_cycle = OFF
+def set_waiting_leds():
+    if USE_NEOPIXEL:
+        np[0] = (255, 255, 255)
+    for led in LEDS:
+        led.duty_cycle = BRIGHT
 
-    def set_led(index, duty):
-        LEDS[index].duty_cycle = duty
-
-    def set_waiting_leds():
+def flash_all(times=3, on_ms=80, off_ms=80):
+    for _ in range(times):
+        if USE_NEOPIXEL:
+            np[0] = (255, 255, 255)
         for led in LEDS:
             led.duty_cycle = BRIGHT
-
-    def flash_all(times=3, on_ms=80, off_ms=80):
-        for _ in range(times):
-            set_waiting_leds()
-            time.sleep(on_ms / 1000)
-            all_leds_off()
-            time.sleep(off_ms / 1000)
-
-    KNIGHT_SEQUENCE = [0, 1, 2, 1]
-    knight_step = 0
-    knight_prev = -1
-    knight_next = 0
+        time.sleep(on_ms / 1000)
+        if USE_NEOPIXEL:
+            np[0] = (0, 0, 0)
+        for led in LEDS:
+            led.duty_cycle = OFF
+        time.sleep(off_ms / 1000)
 
 # ── Notification flash helper ─────────────────────────────────
 def flash_for_level(level):
     all_leds_off()
     if level == "error":
-        if USE_NEOPIXEL:
-            neo_flash(255, 0, 0, times=5, on_ms=100, off_ms=100)
-        else:
-            for _ in range(5):
-                set_led(2, BRIGHT)
-                time.sleep(0.1)
-                set_led(2, OFF)
-                time.sleep(0.1)
+        for _ in range(5):
+            if USE_NEOPIXEL:
+                np[0] = (255, 0, 0)
+            set_led(2, BRIGHT)
+            time.sleep(0.1)
+            if USE_NEOPIXEL:
+                np[0] = (0, 0, 0)
+            set_led(2, OFF)
+            time.sleep(0.1)
     elif level == "warn":
-        if USE_NEOPIXEL:
-            neo_flash(255, 165, 0, times=3)  # orange
-        else:
-            flash_all(times=3)
+        for _ in range(3):
+            if USE_NEOPIXEL:
+                np[0] = (255, 165, 0)  # orange
+            for led in LEDS:
+                led.duty_cycle = BRIGHT
+            time.sleep(0.2)
+            if USE_NEOPIXEL:
+                np[0] = (0, 0, 0)
+            for led in LEDS:
+                led.duty_cycle = OFF
+            time.sleep(0.08)
     else:
-        if USE_NEOPIXEL:
-            neo_flash(255, 255, 255, times=1, on_ms=200)  # white
-        else:
-            flash_all(times=1, on_ms=200)
+        flash_all(times=1, on_ms=200)
 
 # ── Serial helpers ────────────────────────────────────────────
 serial_buf = ""
@@ -201,11 +198,10 @@ while True:
             all_leds_off()
             send_key(Keycode.ONE)
             if USE_NEOPIXEL:
-                neo_flash(0, 255, 0, times=1, on_ms=200)   # green
-            else:
-                set_led(0, BRIGHT)
-                time.sleep(0.2)
-                all_leds_off()
+                np[0] = (0, 255, 0)  # green
+            set_led(0, BRIGHT)
+            time.sleep(0.2)
+            all_leds_off()
             last_press = now
 
         elif not btn_always_allow.value or not btn_reject.value:
@@ -225,20 +221,18 @@ while True:
                 all_leds_off()
                 send_key(Keycode.TWO)
                 if USE_NEOPIXEL:
-                    neo_flash(0, 0, 255, times=1, on_ms=200)  # blue
-                else:
-                    set_led(1, BRIGHT)
-                    time.sleep(0.2)
-                    all_leds_off()
+                    np[0] = (0, 0, 255)  # blue
+                set_led(1, BRIGHT)
+                time.sleep(0.2)
+                all_leds_off()
             elif btn3:
                 all_leds_off()
                 send_key(Keycode.THREE)
                 if USE_NEOPIXEL:
-                    neo_flash(255, 0, 0, times=1, on_ms=200)  # red
-                else:
-                    set_led(2, BRIGHT)
-                    time.sleep(0.2)
-                    all_leds_off()
+                    np[0] = (255, 0, 0)  # red
+                set_led(2, BRIGHT)
+                time.sleep(0.2)
+                all_leds_off()
             last_press = now
 
     # ── Permission timeout ────────────────────────────────────

--- a/firmware/code.py
+++ b/firmware/code.py
@@ -3,14 +3,14 @@ Gavel – Claude Code physical controller
 Raspberry Pi Pico / Waveshare RP2040 Zero firmware (CircuitPython)
 
 Buttons (both boards):
-  GP2 → Allow Once   → sends '1'
-  GP3 → Always Allow → sends '2'
-  GP4 → Reject       → sends '3'
+  GP14 → Allow Once   → sends '1'
+  GP15 → Always Allow → sends '2'
+  GP26 → Reject       → sends '3'
 
 Regular LED mode (Raspberry Pi Pico):
-  GP10 → Allow Once   (green)
-  GP11 → Always Allow (green)
-  GP12 → Reject       (red)
+  GP2 → Allow Once   (green)
+  GP3 → Always Allow (green)
+  GP4 → Reject       (red)
 
 NeoPixel mode (Waveshare RP2040 Zero):
   GP16 → RGB NeoPixel — color-coded per event
@@ -66,9 +66,16 @@ def make_button(pin):
     b.pull = digitalio.Pull.UP
     return b
 
-btn_allow_once   = make_button(board.GP2)
-btn_always_allow = make_button(board.GP3)
-btn_reject       = make_button(board.GP4)
+btn_allow_once   = make_button(board.GP14)
+btn_always_allow = make_button(board.GP15)
+btn_reject       = make_button(board.GP26)
+
+# Each entry: (button_object, keycode, NeoPixel_color, discrete_LED_index)
+BUTTONS = [
+    (btn_allow_once,   Keycode.ONE,   (0, 255, 0), 0),
+    (btn_always_allow, Keycode.TWO,   (0, 0, 255), 1),
+    (btn_reject,       Keycode.THREE, (255, 0, 0), 2),
+]
 
 # ── LED setup ─────────────────────────────────────────────────
 import pwmio
@@ -81,9 +88,9 @@ OFF    = 0
 def make_led(pin):
     return pwmio.PWMOut(pin, frequency=1000, duty_cycle=OFF)
 
-led_allow_once   = make_led(board.GP10)
-led_always_allow = make_led(board.GP11)
-led_reject       = make_led(board.GP12)
+led_allow_once   = make_led(board.GP2)
+led_always_allow = make_led(board.GP3)
+led_reject       = make_led(board.GP4)
 LEDS   = [led_allow_once, led_always_allow, led_reject]
 
 if USE_NEOPIXEL:
@@ -176,6 +183,15 @@ def send_key(keycode):
     kbd.release_all()
     time.sleep(0.05)
 
+def press_button(keycode, color, led_idx):
+    all_leds_off()
+    send_key(keycode)
+    if USE_NEOPIXEL:
+        np[0] = color
+    set_led(led_idx, BRIGHT)
+    time.sleep(0.2)
+    all_leds_off()
+
 # ── Startup flash ─────────────────────────────────────────────
 flash_all(times=2, on_ms=100, off_ms=100)
 
@@ -197,44 +213,27 @@ while True:
     # ── Button input ──────────────────────────────────────────
     if (now - last_press) > DEBOUNCE_MS:
         if not btn_allow_once.value:
-            all_leds_off()
-            send_key(Keycode.ONE)
-            if USE_NEOPIXEL:
-                np[0] = (0, 255, 0)  # green
-            set_led(0, BRIGHT)
-            time.sleep(0.2)
-            all_leds_off()
+            press_button(*BUTTONS[0][1:])
             last_press = now
 
         elif not btn_always_allow.value or not btn_reject.value:
             # Wait 40ms to see if both get pressed (combo window)
             time.sleep(0.04)
-            btn2 = not btn_always_allow.value
-            btn3 = not btn_reject.value
+            b2 = not btn_always_allow.value
+            b3 = not btn_reject.value
 
-            if btn2 and btn3:
+            if b2 and b3:
                 # Combo: toggle KITT / breathing mode
                 if (now - last_combo) > 500:
                     kitt_enabled = not kitt_enabled
                     if not kitt_enabled:
                         all_leds_off()
                     last_combo = now
-            elif btn2:
-                all_leds_off()
-                send_key(Keycode.TWO)
-                if USE_NEOPIXEL:
-                    np[0] = (0, 0, 255)  # blue
-                set_led(1, BRIGHT)
-                time.sleep(0.2)
-                all_leds_off()
-            elif btn3:
-                all_leds_off()
-                send_key(Keycode.THREE)
-                if USE_NEOPIXEL:
-                    np[0] = (255, 0, 0)  # red
-                set_led(2, BRIGHT)
-                time.sleep(0.2)
-                all_leds_off()
+            else:
+                for btn, keycode, color, led_idx in BUTTONS[1:]:
+                    if not btn.value:
+                        press_button(keycode, color, led_idx)
+                        break
             last_press = now
 
     # ── Permission timeout ────────────────────────────────────

--- a/firmware/code.py
+++ b/firmware/code.py
@@ -73,16 +73,19 @@ btn_reject       = make_button(board.GP4)
 # ── LED setup ─────────────────────────────────────────────────
 import pwmio
 
+# RP2040 Zero PCB uses common-anode LEDs (active-low): GPIO LOW = on.
+# Pico uses common-cathode (active-high): GPIO HIGH = on.
+BRIGHT = 0     if USE_NEOPIXEL else 65535
+DIM    = 57535 if USE_NEOPIXEL else 8000
+OFF    = 65535 if USE_NEOPIXEL else 0
+
 def make_led(pin):
-    return pwmio.PWMOut(pin, frequency=1000, duty_cycle=0)
+    return pwmio.PWMOut(pin, frequency=1000, duty_cycle=OFF)
 
 led_allow_once   = make_led(board.GP10)
 led_always_allow = make_led(board.GP11)
 led_reject       = make_led(board.GP12)
 LEDS   = [led_allow_once, led_always_allow, led_reject]
-BRIGHT = 65535
-DIM    = 8000
-OFF    = 0
 
 if USE_NEOPIXEL:
     import neopixel

--- a/firmware/requirements.txt
+++ b/firmware/requirements.txt
@@ -1,7 +1,11 @@
-# CircuitPython libraries needed on the Pico's /lib folder
+# CircuitPython libraries needed in CIRCUITPY/lib/
 # Download from: https://circuitpython.org/libraries
 #
-# adafruit_hid/          (folder — from adafruit-circuitpython-hid)
-#   keyboard.py
-#   keycode.py
-#   keyboard_layout_us.py
+# All boards:
+#   adafruit_hid/          (folder — from adafruit-circuitpython-hid)
+#     keyboard.py
+#     keycode.py
+#     keyboard_layout_us.py
+#
+# RP2040 Zero / XIAO RP2040 only (NeoPixel boards):
+#   neopixel.mpy           (from adafruit-circuitpython-neopixel)

--- a/firmware/test_leds.py
+++ b/firmware/test_leds.py
@@ -2,7 +2,7 @@
 Gavel – LED test script
 
 Cycles through each LED independently to verify wiring.
-  GP10 (green) → GP11 (green) → GP12 (red) → repeat
+  GP2 (green) → GP3 (green) → GP4 (red) → repeat
 
 Copy this file to the CIRCUITPY drive as code.py to run the test.
 Restore the original code.py when done.
@@ -18,14 +18,14 @@ def make_led(pin):
     led.value = False
     return led
 
-led_allow_once   = make_led(board.GP10)  # green
-led_always_allow = make_led(board.GP11)  # green
-led_reject       = make_led(board.GP12)  # red
+led_allow_once   = make_led(board.GP2)  # green
+led_always_allow = make_led(board.GP3)  # green
+led_reject       = make_led(board.GP4)  # red
 
 leds = [
-    (led_allow_once,   "GP10 - Allow Once   (green)"),
-    (led_always_allow, "GP11 - Always Allow (green)"),
-    (led_reject,       "GP12 - Reject       (red)"),
+    (led_allow_once,   "GP2 - Allow Once   (green)"),
+    (led_always_allow, "GP3 - Always Allow (green)"),
+    (led_reject,       "GP4 - Reject       (red)"),
 ]
 
 print("LED test starting...")

--- a/hardware/wiring.md
+++ b/hardware/wiring.md
@@ -5,7 +5,7 @@ Both supported boards use the same GPIO numbers. Board type is auto-detected —
 | Board | LED output |
 |-------|------------|
 | Raspberry Pi Pico | 3× discrete LEDs on GP10/GP11/GP12 |
-| Waveshare RP2040 Zero | RGB NeoPixel on GP16 (built-in) |
+| Waveshare RP2040 Zero | Built-in RGB NeoPixel on GP16 + 3× discrete LEDs on GP10/GP11/GP12 |
 
 ---
 
@@ -41,7 +41,25 @@ GPIO pin ──[220Ω]──[LED anode → cathode]── GND
 
 ## LEDs — Waveshare RP2040 Zero
 
-The RP2040 Zero has a built-in RGB NeoPixel on GP16. No external LEDs or resistors needed.
+The RP2040 Zero drives both the built-in RGB NeoPixel (GP16) and three discrete LEDs (GP10/GP11/GP12) simultaneously.
+
+### Discrete LEDs
+
+Same pin assignment and wiring as the Pico. Each LED needs a 220Ω resistor in series.
+
+| LED          | GPIO | Color |
+|--------------|------|-------|
+| Allow Once   | GP10 | Green |
+| Always Allow | GP11 | Green |
+| Reject       | GP12 | Red   |
+
+```
+GPIO pin ──[220Ω]──[LED anode → cathode]── GND
+```
+
+### NeoPixel (built-in)
+
+No external LEDs or resistors needed.
 
 Color coding:
 

--- a/hardware/wiring.md
+++ b/hardware/wiring.md
@@ -4,8 +4,8 @@ Both supported boards use the same GPIO numbers. Board type is auto-detected —
 
 | Board | LED output |
 |-------|------------|
-| Raspberry Pi Pico | 3× discrete LEDs on GP10/GP11/GP12 |
-| Waveshare RP2040 Zero | Built-in RGB NeoPixel on GP16 + 3× discrete LEDs on GP10/GP11/GP12 |
+| Raspberry Pi Pico | 3× discrete LEDs on GP2/GP3/GP4 |
+| Waveshare RP2040 Zero | Built-in RGB NeoPixel on GP16 + 3× discrete LEDs on GP2/GP3/GP4 |
 
 ---
 
@@ -16,9 +16,9 @@ The internal pull-up is used — no external resistor needed.
 
 | Button       | GPIO |
 |--------------|------|
-| Allow Once   | GP2  |
-| Always Allow | GP3  |
-| Reject       | GP4  |
+| Allow Once   | GP14 |
+| Always Allow | GP15 |
+| Reject       | GP26 |
 
 Wiring per button:
 ```
@@ -31,9 +31,9 @@ Each LED needs a 220Ω resistor in series.
 
 | LED          | Pico Pin | GPIO | Color |
 |--------------|----------|------|-------|
-| Allow Once   | Pin 14   | GP10 | Green |
-| Always Allow | Pin 15   | GP11 | Green |
-| Reject       | Pin 16   | GP12 | Red   |
+| Allow Once   | Pin 4    | GP2  | Green |
+| Always Allow | Pin 5    | GP3  | Green |
+| Reject       | Pin 6    | GP4  | Red   |
 
 ```
 GPIO pin ──[220Ω]──[LED anode → cathode]── GND
@@ -49,9 +49,9 @@ Same pin assignment and wiring as the Pico. Each LED needs a 220Ω resistor in s
 
 | LED          | GPIO | Color |
 |--------------|------|-------|
-| Allow Once   | GP10 | Green |
-| Always Allow | GP11 | Green |
-| Reject       | GP12 | Red   |
+| Allow Once   | GP2  | Green |
+| Always Allow | GP3  | Green |
+| Reject       | GP4  | Red   |
 
 ```
 GPIO pin ──[220Ω]──[LED anode → cathode]── GND

--- a/hardware/wiring.md
+++ b/hardware/wiring.md
@@ -1,11 +1,11 @@
 # Gavel Wiring Reference
 
-Both supported boards use the same GPIO numbers. Set `USE_NEOPIXEL` in `firmware/code.py` to match your board.
+Both supported boards use the same GPIO numbers. Board type is auto-detected — no manual configuration needed.
 
-| Board | `USE_NEOPIXEL` | LED output |
-|-------|---------------|------------|
-| Raspberry Pi Pico | `False` | 3× discrete LEDs on GP10/GP11/GP12 |
-| Waveshare RP2040 Zero | `True` | RGB NeoPixel on GP16 (built-in) |
+| Board | LED output |
+|-------|------------|
+| Raspberry Pi Pico | 3× discrete LEDs on GP10/GP11/GP12 |
+| Waveshare RP2040 Zero | RGB NeoPixel on GP16 (built-in) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `BUTTONS` list of 4-tuples (button object, keycode, NeoPixel color, LED index) after button setup
- Extract repeated 6-line action block into `press_button(keycode, color, led_idx)` helper
- Replace three duplicated `if/elif` branches with `press_button(*BUTTONS[0][1:])` and a `for` loop over `BUTTONS[1:]`

No behavior change. Adding a 4th button now requires one new line in the BUTTONS table.

Closes #21

## Test plan
- [ ] Flash to Pico — press each of the 3 buttons, verify correct keycode sent and LED lights up
- [ ] Press Button 2 + Button 3 simultaneously — verify KITT/breathing toggle still works
- [ ] Flash to RP2040 Zero — verify NeoPixel colors (green / blue / red) per button