### PR TITLE
feat: log button decisions from Pico to Mac

### DIFF
--- a/firmware/code.py
+++ b/firmware/code.py
@@ -76,11 +76,11 @@ btn_allow_once   = make_button(board.GP14)
 btn_always_allow = make_button(board.GP15)
 btn_reject       = make_button(board.GP26)
 
-# Each entry: (button_object, keycode, NeoPixel_color, discrete_LED_index)
+# Each entry: (button_object, keycode, NeoPixel_color, discrete_LED_index, name)
 BUTTONS = [
-    (btn_allow_once,   Keycode.ONE,   (0, 255, 0), 0),
-    (btn_always_allow, Keycode.TWO,   (0, 0, 255), 1),
-    (btn_reject,       Keycode.THREE, (255, 0, 0), 2),
+    (btn_allow_once,   Keycode.ONE,   (0, 255, 0), 0, "allow_once"),
+    (btn_always_allow, Keycode.TWO,   (0, 0, 255), 1, "always_allow"),
+    (btn_reject,       Keycode.THREE, (255, 0, 0), 2, "reject"),
 ]
 
 # ── LED setup ─────────────────────────────────────────────────
@@ -208,12 +208,13 @@ def send_key(keycode):
     kbd.release_all()
     time.sleep(0.05)
 
-def press_button(keycode, color, led_idx):
+def press_button(keycode, color, led_idx, name="unknown"):
     all_leds_off()
     send_key(keycode)
     if USE_NEOPIXEL:
         np[0] = color
     set_led(led_idx, BRIGHT)
+    serial.write((json.dumps({"event": "button", "button": name}) + "\n").encode())
 
 # ── Startup flash ─────────────────────────────────────────────
 flash_all(times=2, on_ms=100, off_ms=100)
@@ -265,9 +266,9 @@ while True:
                         all_leds_off()
                     last_combo = now
             else:
-                for btn, keycode, color, led_idx in BUTTONS[1:]:
+                for btn, keycode, color, led_idx, name in BUTTONS[1:]:
                     if not btn.value:
-                        press_button(keycode, color, led_idx)
+                        press_button(keycode, color, led_idx, name)
                         decision_off_at = now + DECISION_HOLD_MS
                         state = STATE_IDLE
                         break

--- a/hooks/pico.py
+++ b/hooks/pico.py
@@ -9,7 +9,8 @@ from typing import Optional
 
 from find_device import find_pico_port
 
-LOG_FILE = os.path.join(os.path.dirname(__file__), "hook.log")
+LOG_FILE      = os.path.join(os.path.dirname(__file__), "hook.log")
+DECISIONS_LOG = os.path.expanduser("~/.claude/gavel/decisions.jsonl")
 
 
 def log(event: str, payload: dict, port: Optional[str]) -> None:
@@ -17,6 +18,24 @@ def log(event: str, payload: dict, port: Optional[str]) -> None:
     device = port if port else "no device"
     with open(LOG_FILE, "a") as f:
         f.write(f"[{ts}] {event} → {json.dumps(payload)}  (port: {device})\n")
+
+
+def _log_button_events(raw: str) -> None:
+    """Parse button event JSON lines from the Pico and append to decisions log."""
+    os.makedirs(os.path.dirname(DECISIONS_LOG), exist_ok=True)
+    ts = datetime.datetime.now().isoformat()
+    with open(DECISIONS_LOG, "a") as f:
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                evt = json.loads(line)
+                if evt.get("event") == "button":
+                    evt["ts"] = ts
+                    f.write(json.dumps(evt) + "\n")
+            except (json.JSONDecodeError, KeyError):
+                pass
 
 
 def send_to_pico(event: str, payload: dict) -> None:
@@ -28,5 +47,8 @@ def send_to_pico(event: str, payload: dict) -> None:
         import serial
         with serial.Serial(port, timeout=1) as ser:  # baud rate is irrelevant over USB CDC
             ser.write((json.dumps(payload) + "\n").encode())
+            # Drain any button events the Pico buffered since the last hook call
+            if ser.in_waiting:
+                _log_button_events(ser.read(ser.in_waiting).decode("utf-8", errors="replace"))
     except Exception as e:
         log(event, {"error": str(e)}, port)


### PR DESCRIPTION
## Summary
- `firmware/code.py`: adds a `name` field to each `BUTTONS` entry (`"allow_once"`, `"always_allow"`, `"reject"`); `press_button()` now writes `{"event":"button","button":<name>}` to the USB serial port after each press
- `hooks/pico.py`: after writing each hook payload, drains the serial read buffer and appends any button events to `~/.claude/gavel/decisions.jsonl` with an ISO timestamp

No background process needed — button events are buffered by the Pico's USB CDC stack and consumed by the next hook call (typically PostToolUse ~1–5 s later).

## Test plan
- [ ] Flash updated `firmware/code.py` to Pico
- [ ] Press a button during a permission prompt
- [ ] Confirm `~/.claude/gavel/decisions.jsonl` gains a new line, e.g. `{"event":"button","button":"allow_once","ts":"2026-..."}`
- [ ] Check no regression: hook scripts still send LED commands correctly

Closes #5