### PR TITLE
feat: tool-specific NeoPixel colors per risk category

### DIFF
--- a/firmware/code.py
+++ b/firmware/code.py
@@ -120,20 +120,26 @@ def set_led(index, duty):
 
 def set_permission_leds(category):
     """Set LEDs based on tool risk category.
-    destructive → all bright (high alert)
-    readonly    → center LED dim (low stakes)
+    destructive → all bright red  (high alert)
+    write       → two LEDs dim    (medium risk)
+    readonly    → one LED dim     (low stakes)
     network     → handled by blink loop in main
     """
     all_leds_off()
     if category == "readonly":
         if USE_NEOPIXEL:
-            np[0] = (0, 180, 0)   # green
+            np[0] = (0, 0, 255)   # blue
+        set_led(1, DIM)
+    elif category == "write":
+        if USE_NEOPIXEL:
+            np[0] = (255, 200, 0)  # yellow
+        set_led(0, DIM)
         set_led(1, DIM)
     elif category == "network":
         pass  # blink loop takes over immediately
     else:  # destructive (default)
         if USE_NEOPIXEL:
-            np[0] = (255, 255, 255)
+            np[0] = (255, 0, 0)   # red
         for led in LEDS:
             led.duty_cycle = BRIGHT
 

--- a/hooks/pre_tool.py
+++ b/hooks/pre_tool.py
@@ -11,12 +11,15 @@ sys.path.insert(0, os.path.dirname(__file__))
 from pico import send_to_pico
 
 READONLY_TOOLS = {"Read", "Glob", "Grep", "LS"}
+WRITE_TOOLS    = {"Edit", "Write", "MultiEdit", "NotebookEdit"}
 NETWORK_TOOLS  = {"WebFetch", "WebSearch", "Agent"}
 
 
 def classify(tool_name):
     if tool_name in READONLY_TOOLS:
         return "readonly"
+    if tool_name in WRITE_TOOLS:
+        return "write"
     if tool_name in NETWORK_TOOLS:
         return "network"
     return "destructive"

--- a/hooks/test_leds.py
+++ b/hooks/test_leds.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+LED test utility for Gavel — visually verify all LED patterns with Pico connected.
+
+Usage:
+  python3 hooks/test_leds.py
+"""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(__file__))
+from find_device import find_pico_port
+from pico import send_to_pico
+
+HOLD = 3  # seconds to hold permission states
+
+STEPS = [
+    # (payload, label, what to expect)
+    (
+        {"type": "permission", "category": "readonly"},
+        "readonly",
+        "NeoPixel: BLUE       | Discrete: center LED dim",
+    ),
+    (
+        {"type": "permission", "category": "write"},
+        "write",
+        "NeoPixel: YELLOW     | Discrete: two LEDs dim",
+    ),
+    (
+        {"type": "permission", "category": "network"},
+        "network",
+        "NeoPixel: ORANGE blink | Discrete: blink",
+    ),
+    (
+        {"type": "permission", "category": "destructive"},
+        "destructive",
+        "NeoPixel: RED        | Discrete: all bright",
+    ),
+    (
+        {"type": "notification", "level": "info"},
+        "notify info",
+        "All LEDs: 1 slow flash",
+    ),
+    (
+        {"type": "notification", "level": "warn"},
+        "notify warn",
+        "All LEDs: 3 medium flashes",
+    ),
+    (
+        {"type": "notification", "level": "error"},
+        "notify error",
+        "LED 3 only: 5 fast red flashes",
+    ),
+    (
+        {"type": "idle"},
+        "idle",
+        "All LEDs off",
+    ),
+]
+
+# ── Preflight ─────────────────────────────────────────────────
+print("=" * 58)
+print("Gavel LED Test")
+print("=" * 58)
+
+port = find_pico_port()
+if not port:
+    print("ERROR: Pico not found. Plug it in and try again.")
+    sys.exit(1)
+
+print(f"Pico found: {port}")
+print()
+
+# ── Run steps ─────────────────────────────────────────────────
+for payload, label, expected in STEPS:
+    is_notification = payload.get("type") == "notification"
+    is_idle         = payload.get("type") == "idle"
+
+    print(f"  [{label}]")
+    print(f"    Expect: {expected}")
+
+    send_to_pico("test", payload)
+
+    if is_notification or is_idle:
+        time.sleep(1.5)  # wait for flash animation to finish
+    else:
+        time.sleep(HOLD)
+
+    print()
+
+print("Done.")


### PR DESCRIPTION
## Summary
- `hooks/pre_tool.py`: adds `WRITE_TOOLS = {"Edit","Write","MultiEdit","NotebookEdit"}` and a new `"write"` classification between readonly and destructive
- `firmware/code.py`: `set_permission_leds` now uses distinct colors/patterns per category:

| Category | NeoPixel | Discrete LEDs |
|----------|----------|---------------|
| readonly | blue | 1 LED dim |
| write | yellow | 2 LEDs dim |
| network | orange blink | blink |
| destructive | red | all bright |

**Note:** this PR is based on `feature/4-led-patterns-per-tool-category` (PR #28). Merge #28 first, then merge this.

## Test plan
- [ ] Flash updated `firmware/code.py`
- [ ] Trigger a Read tool → NeoPixel shows blue
- [ ] Trigger an Edit tool → NeoPixel shows yellow
- [ ] Trigger a Bash tool → NeoPixel shows red
- [ ] Trigger a WebFetch → orange blink

Closes #17